### PR TITLE
Add `globalException` receiver for receive unobserved error to logger

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -39,8 +39,7 @@ public class App : Application
     {
         // Status bar view model need to be initialized first before initialize logger
         _statusBarViewModel = new StatusBarViewModel();
-        SetupLogging();
-        InitializeLogger();
+        Logger.AddStatusBarSinkConfiguration(_statusBarViewModel);
         
         var collection = new ServiceCollection();
         collection.AddSingleton(_statusBarViewModel);
@@ -181,8 +180,6 @@ public class App : Application
 #else
         _loggerConfiguration.MinimumLevel.Information();
 #endif
-        
-        
     }
 
     /// <summary>

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.ReactiveUI;
 using System;
+using KanaMelody.Utilities;
+using Serilog;
 using Velopack;
 
 namespace KanaMelody;
@@ -13,6 +15,13 @@ sealed class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // To receive unhandled exceptions from all threads in the application to the logger
+        // the logger must be initialized before everything else
+        Logger.CleanOldLogFiles();
+        Logger.InitializeLogger();
+        AppDomain currentDomain = AppDomain.CurrentDomain;
+        currentDomain.UnhandledException += GlobalUnhandledExceptionHandler;
+        
         VelopackApp.Build().Run();
         BuildAvaloniaApp()
             .StartWithClassicDesktopLifetime(args);
@@ -25,4 +34,9 @@ sealed class Program
             .WithInterFont()
             .LogToTrace()
             .UseReactiveUI();
+
+    private static void GlobalUnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)
+    {
+        Log.Error(e.ExceptionObject as Exception, "Unhandled exception");
+    }
 }

--- a/Utilities/Logger.cs
+++ b/Utilities/Logger.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using KanaMelody.Development;
+using KanaMelody.Services;
+using KanaMelody.ViewModels;
+using Serilog;
+
+namespace KanaMelody.Utilities;
+
+/// <summary>
+/// Helper class to manage the logger.
+/// </summary>
+public static class Logger
+{
+    /// <summary>
+    /// Initialize the logger with the basic configuration.
+    /// </summary>
+    public static void InitializeLogger()
+    {
+        Log.Logger = CreateLoggerConfiguration().CreateLogger();
+        LogHeader();
+    }
+    
+    /// <summary>
+    /// Create basic logger configuration.
+    /// </summary>
+    public static LoggerConfiguration CreateLoggerConfiguration()
+    {
+        var logFileName = $"log-{(int)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds}-{Guid.NewGuid()}.log";
+        var outputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}]: {Message:lj}{NewLine}{Exception}";
+        
+        // Log to console and file with rotate log file every session, also delete old log files after exceed 20 session
+        LoggerConfiguration loggerConfiguration = new LoggerConfiguration()
+            .WriteTo.Console(outputTemplate: outputTemplate)
+            .WriteTo.File(
+                Path.Combine(StorageService.LogFullPath, logFileName),
+                outputTemplate: outputTemplate,
+                retainedFileCountLimit: 20
+            );
+        
+#if DEBUG
+        loggerConfiguration.MinimumLevel.Debug();
+#else
+        loggerConfiguration.MinimumLevel.Information();
+#endif
+        
+        return loggerConfiguration;
+    }
+
+    /// <summary>
+    /// Add status bar sink configuration to the old logger.
+    /// </summary>
+    /// <param name="statusBarViewModel">The status bar view model that will be used to display the log.</param>
+    public static void AddStatusBarSinkConfiguration(StatusBarViewModel statusBarViewModel)
+    {
+        LoggerConfiguration basicConfiguration = CreateLoggerConfiguration();
+        Log.Logger = basicConfiguration.WriteTo.Sink(new StatusBarLogSink(statusBarViewModel)).CreateLogger();
+    }
+
+    /// <summary>
+    /// Write the initial log.
+    /// </summary>
+    public static void LogHeader()
+    {
+        Log.Information("------------------------------------");
+        Log.Information("Log for KanaMelody {Version} (Debug: {IsDebug})", DebugUtils.GetVersion(), DebugUtils.IsDebugBuild);
+        Log.Information("Framework : {Framework}", RuntimeInformation.FrameworkDescription);
+        Log.Information("Environment: {RuntimeInfo} ({OSVersion}), {ProcessorCount} cores {Architecture}", RuntimeInfo.OS, Environment.OSVersion, Environment.ProcessorCount, RuntimeInformation.OSArchitecture);
+        Log.Information("------------------------------------");
+    }
+    
+    /// <summary>
+    /// Clean old log files.
+    /// </summary>
+    public static void CleanOldLogFiles()
+    {
+        StorageService.CleanOldLogFiles();
+    }
+}


### PR DESCRIPTION
Most error are logged in program console but not in logger so when there are some exception occured in the main thread on released program there are no observer that catched the error to the logger for further investigation. This PR make this happened. Also move some reusable logger class to new helper class.